### PR TITLE
Ensure full sync pagination and load Leaflet map

### DIFF
--- a/backend/src/routes/sync.ts
+++ b/backend/src/routes/sync.ts
@@ -81,15 +81,15 @@ router.post('/refresh', async (req: Request, res: Response) => {
     // Initialize sync service
     const syncService = new SyncService(apiClient, user);
 
-    // Run full sync with unlimited pagination (set high limit)
-    const maxPages = req.body.maxPages || 100; // Allow up to 100 pages by default
-    
+    // Run full sync, paginate until end unless a limit is provided
+    const maxPages = req.body.maxPages; // Undefined means no manual limit
+
     // Progress callback to update sync status
     const progressCallback = (progress: number, message: string) => {
       syncStatus.progress = progress;
       syncStatus.message = message;
     };
-    
+
     const syncResult = await syncService.syncAllData(maxPages, progressCallback);
 
     if (!syncResult.success) {

--- a/backend/src/services/geoguessrApi.ts
+++ b/backend/src/services/geoguessrApi.ts
@@ -121,7 +121,7 @@ export class GeoGuessrApiClient {
   /**
    * Get all game tokens from feed (with pagination)
    */
-  async getAllGameTokens(maxPages: number = 100): Promise<string[]> {
+  async getAllGameTokens(maxPages: number = Number.POSITIVE_INFINITY): Promise<string[]> {
     const gameTokens: string[] = [];
     const seenTokens = new Set<string>(); // Use Set for faster lookups
     let paginationToken: string | undefined;
@@ -133,9 +133,10 @@ export class GeoGuessrApiClient {
     while (pageCount < maxPages) {
       try {
         const feed = await this.getFeed(paginationToken);
-        
-        console.log(`📄 Page ${pageCount + 1}: ${feed.entries.length} entries`);
-        
+        pageCount++;
+
+        console.log(`📄 Page ${pageCount}: ${feed.entries.length} entries`);
+
         let newTokensThisPage = 0;
 
         // Extract game tokens from this page
@@ -177,16 +178,16 @@ export class GeoGuessrApiClient {
         }
 
         paginationToken = feed.paginationToken;
-        pageCount++;
 
         // Small delay to be respectful to the API
         await new Promise(resolve => setTimeout(resolve, 800));
 
       } catch (error) {
         console.error(`❌ Failed to fetch page ${pageCount + 1}:`, error);
+        // Count the failed page to avoid infinite loops
+        pageCount++;
         // Don't break immediately, try next page after a longer delay
         await new Promise(resolve => setTimeout(resolve, 2000));
-        pageCount++;
         continue;
       }
     }

--- a/backend/src/services/syncService.ts
+++ b/backend/src/services/syncService.ts
@@ -20,7 +20,7 @@ export class SyncService {
   /**
    * Sync all user's game data
    */
-  async syncAllData(maxPages: number = 100, progressCallback?: (progress: number, message: string) => void): Promise<SyncResult> {
+  async syncAllData(maxPages: number = Number.POSITIVE_INFINITY, progressCallback?: (progress: number, message: string) => void): Promise<SyncResult> {
     const startTime = Date.now();
     const result: SyncResult = {
       success: false,

--- a/frontend/src/components/InteractiveMap.tsx
+++ b/frontend/src/components/InteractiveMap.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { MapContainer, TileLayer, Marker, Popup, Polyline } from 'react-leaflet';
 import { type LatLngExpression } from 'leaflet';
 import L from 'leaflet';
+import 'leaflet/dist/leaflet.css';
 import Layout from './Layout';
 import Loading from './Loading';
 import RefreshButton from './RefreshButton';

--- a/frontend/src/components/RefreshButton.tsx
+++ b/frontend/src/components/RefreshButton.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { RefreshCw } from 'lucide-react';
 import { apiClient } from '../lib/api';
-import { generateDemoUserId } from '../lib/utils';
 
 interface RefreshButtonProps {
   onRefreshComplete?: () => void;
@@ -16,10 +15,8 @@ export default function RefreshButton({ onRefreshComplete, className = '' }: Ref
     try {
       setIsRefreshing(true);
       
-      // Call the real sync API endpoint with pagination for complete data
-      const response = await apiClient.refreshAllData({
-        maxPages: 100 // Fetch up to 100 pages for complete sync
-      });
+      // Call the sync API endpoint and paginate until the end
+      const response = await apiClient.refreshAllData();
       
       if (response.success) {
         setLastRefresh(new Date().toLocaleTimeString());


### PR DESCRIPTION
## Summary
- allow sync endpoint to paginate through entire GeoGuessr feed
- have refresh button call sync without page limit
- load interactive map by importing Leaflet CSS

## Testing
- `npm run test:backend`

------
https://chatgpt.com/codex/tasks/task_e_68976a4242b4832a93cf69ad997acfc8